### PR TITLE
Add new window cycling system with legacy support.

### DIFF
--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -66,12 +66,18 @@ class WinWizardSettingsPanel(gsd.SettingsPanel):
 		# Translators: Label of a checkbox which can be used to enable or disable sounds.
 		self.enableBeepsChk = sHelper.addItem(wx.CheckBox(self, label=_("&Confirm actions with sounds")))
 		self.enableBeepsChk.SetValue(config.conf["winWizard"]["playConfirmationBeeps"])
+		self.useOldCycleChk = sHelper.addItem(
+			wx.CheckBox(self, label=_("Use old window cycling behavior"))
+		)
+		self.useOldCycleChk.SetValue(config.conf["winWizard"]["useOldCycle"])
+
 
 	def postInit(self):
 		self.enableBeepsChk.SetFocus()
 
 	def onSave(self):
 		config.conf["winWizard"]["playConfirmationBeeps"] = self.enableBeepsChk.GetValue()
+		config.conf["winWizard"]["useOldCycle"] = self.useOldCycleChk.GetValue()
 
 
 class Win32FunctionError(Exception):
@@ -565,11 +571,15 @@ def disableInSecureMode(decoratedCls):
 @disableInSecureMode
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
+
 	scriptCategory = _("Win Wizard")
 
 	def __init__(self):
 		super().__init__()
-		confSpec = {"playConfirmationBeeps": "boolean(default=True)"}
+		confSpec = {
+			"playConfirmationBeeps": "boolean(default=True)",
+			"useOldCycle": "boolean(default=False)"
+		}
 		config.conf.spec["winWizard"] = confSpec
 		self.hiddenWindowsList: hiddenWindowsList = hiddenWindowsList()
 		gsd.NVDASettingsDialog.categoryClasses.append(WinWizardSettingsPanel)
@@ -580,45 +590,142 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		del self.hiddenWindowsList
 		gsd.NVDASettingsDialog.categoryClasses.remove(WinWizardSettingsPanel)
 
+
+
+
+
 	@scriptHandler.script(
 		description=_(
-			# Translators: Description of the keyboard command
-			# allowing to jump between top-level windows of the current application.
-			"Jumps between top-level windows of the current application."
+			"Cycles through top-level windows of the current application."
 		),
 		gesture="kb:NVDA+windows+Tab",
 	)
+
 	def script_cycleWindows(self, gesture):
-		if(
-			api.getForegroundObject()
-			and api.getForegroundObject().parent
-			and hasattr(api.getForegroundObject().parent, "appModule")
-		):
-			topWindow = api.getForegroundObject().parent
-			topWindowAppModule = api.getForegroundObject().parent.appModule
-			if topWindowAppModule.appName == "explorer":
-				# Translators: Information given when user tries to move to top-level window in Windows  Explorer
-				ui.message(_("Not supported here."))
-				return
-			nextTopWin = prevTopWin = None
-			if topWindow.simplePrevious and topWindow.simplePrevious.appModule == topWindowAppModule:
-				prevTopWin = topWindow.simplePrevious
-			if topWindow.simpleNext and topWindow.simpleNext.appModule == topWindowAppModule:
-				nextTopWin = topWindow.simpleNext
-			if not prevTopWin and not nextTopWin:
-				# Translators: Announced when the current application has no top-level windows.
-				ui.message(_("This window has no top level windows to cycle to."))
-				return
-			elif prevTopWin and not nextTopWin:
-				prevTopWin.setFocus()
-			elif not prevTopWin and nextTopWin:
-				nextTopWin.setFocus()
+		if config.conf["winWizard"]["useOldCycle"]:
+			if(
+				api.getForegroundObject()
+				and api.getForegroundObject().parent
+				and hasattr(api.getForegroundObject().parent, "appModule")
+			):
+				topWindow = api.getForegroundObject().parent
+				topWindowAppModule = api.getForegroundObject().parent.appModule
+				if topWindowAppModule.appName == "explorer":
+					# Translators: Information given when user tries to move to top-level window in Windows  Explorer
+					ui.message(_("Not supported here."))
+					return
+				nextTopWin = prevTopWin = None
+				if topWindow.simplePrevious and topWindow.simplePrevious.appModule == topWindowAppModule:
+					prevTopWin = topWindow.simplePrevious
+				if topWindow.simpleNext and topWindow.simpleNext.appModule == topWindowAppModule:
+					nextTopWin = topWindow.simpleNext
+				if not prevTopWin and not nextTopWin:
+					# Translators: Announced when the current application has no top-level windows.
+					ui.message(_("This window has no top level windows to cycle to."))
+					return
+				elif prevTopWin and not nextTopWin:
+					prevTopWin.setFocus()
+				elif not prevTopWin and nextTopWin:
+					nextTopWin.setFocus()
+				else:
+					# Translators: Announced when current program has multiple top-level windows.
+					ui.message(_("Multiple top level windows detected."))
 			else:
-				# Translators: Announced when current program has multiple top-level windows.
-				ui.message(_("Multiple top level windows detected."))
-		else:
-			# Translators: Reported when informations for the current window cannot be retrieved.
+				# Translators: Reported when informations for the current window cannot be retrieved.
+				ui.message(_("Can't retrieve window information for this object."))
+			return
+
+		fg = api.getForegroundObject()
+		parent = getattr(fg, "parent", None)
+		if not parent:
 			ui.message(_("Can't retrieve window information for this object."))
+			return
+		appModule = parent.appModule
+		# Reset cycle state if app changed
+		if getattr(self, "_cycleApp", None) != appModule:
+			self._cycleIndex = None
+			self._cycleSelection = None
+			self._cycleWindows = None
+			self._cycleApp = appModule
+		if appModule.appName == "explorer":
+			ui.message(_("Not supported here."))
+			return
+		# Build window list
+		windows = []
+		current = parent
+		while current.simplePrevious and current.simplePrevious.appModule == appModule:
+			current = current.simplePrevious
+		while current:
+			if current.appModule == appModule:
+				windows.append(current)
+			current = current.simpleNext
+		if len(windows) <= 1:
+			ui.message(_("This window has no top level windows to cycle to."))
+			return
+		# Initialize index if needed
+		if getattr(self, "_cycleIndex", None) is None:
+			try:
+				self._cycleIndex = windows.index(parent)
+			except ValueError:
+				self._cycleIndex = 0
+		# Move forward
+		self._cycleIndex = (self._cycleIndex + 1) % len(windows)
+		# Store selection
+		self._cycleWindows = windows
+		self._cycleSelection = windows[self._cycleIndex]
+		# Announce
+		ui.message(_("{name} ({index} of {total})").format(
+			name=self._cycleSelection.name or _("Unknown window"),
+			index=self._cycleIndex + 1,
+			total=len(windows)
+		))
+
+	@scriptHandler.script(
+		description=_(
+			"Focuses the currently selected window from the cycle."
+		),
+		gesture="kb:NVDA+windows+`",
+	)
+	def script_confirmCycleWindow(self, gesture):
+		# Disable in old mode
+		if config.conf["winWizard"]["useOldCycle"]:
+			ui.message(_("This command is disabled in old mode."))
+			return
+		selection = getattr(self, "_cycleSelection", None)
+		if not selection:
+			ui.message(_("No window selected."))
+			return
+		fg = api.getForegroundObject()
+		parent = getattr(fg, "parent", None)
+		if not parent:
+			ui.message(_("No window selected."))
+			return
+		# App mismatch check
+		if getattr(self, "_cycleApp", None) != parent.appModule:
+			ui.message(_("No window selected."))
+			self._resetCycleState()
+			return
+		# Window validity check
+		if (
+			not hasattr(selection, "windowHandle")
+			or not winUser.isWindow(selection.windowHandle)
+		):
+			ui.message(_("Window no longer available."))
+			return
+		try:
+			selection.setFocus()
+			playTonesIfEnabled(180, 50)
+		except Exception:
+			ui.message(_("Failed to focus window."))
+		self._resetCycleState()
+	# Helper
+	def _resetCycleState(self):
+		self._cycleSelection = None
+		self._cycleWindows = None
+		self._cycleIndex = None
+		self._cycleApp = None
+
+
 
 	@scriptHandler.script(
 		# Translators: Description of the keyboard command that kills currently focused process.

--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -66,6 +66,7 @@ class WinWizardSettingsPanel(gsd.SettingsPanel):
 		# Translators: Label of a checkbox which can be used to enable or disable sounds.
 		self.enableBeepsChk = sHelper.addItem(wx.CheckBox(self, label=_("&Confirm actions with sounds")))
 		self.enableBeepsChk.SetValue(config.conf["winWizard"]["playConfirmationBeeps"])
+		# Translators: Label of a checkbox to enable legacy window switching behavior.
 		self.useOldCycleChk = sHelper.addItem(
 			wx.CheckBox(self, label=_("Use old window cycling behavior"))
 		)
@@ -638,6 +639,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		fg = api.getForegroundObject()
 		parent = getattr(fg, "parent", None)
 		if not parent:
+			# Translators: Reported when informations for the current window cannot be retrieved.
 			ui.message(_("Can't retrieve window information for this object."))
 			return
 		appModule = parent.appModule
@@ -648,6 +650,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self._cycleWindows = None
 			self._cycleApp = appModule
 		if appModule.appName == "explorer":
+			# Translators: Information given when user tries to move to top-level window in Windows  Explorer.
 			ui.message(_("Not supported here."))
 			return
 		# Build window list
@@ -660,6 +663,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				windows.append(current)
 			current = current.simpleNext
 		if len(windows) <= 1:
+			# Translators: Announced when the current application has no top-level windows.
 			ui.message(_("This window has no top level windows to cycle to."))
 			return
 		# Initialize index if needed
@@ -673,7 +677,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Store selection
 		self._cycleWindows = windows
 		self._cycleSelection = windows[self._cycleIndex]
-		# Announce
+		# Translators: Announces the currently selected window when cycling.
+		# {name} is the window title, {index} is current position, {total} is total windows.
 		ui.message(_("{name} ({index} of {total})").format(
 			name=self._cycleSelection.name or _("Unknown window"),
 			index=self._cycleIndex + 1,
@@ -687,17 +692,19 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gesture="kb:NVDA+windows+`",
 	)
 	def script_confirmCycleWindow(self, gesture):
-		# Disable in old mode
 		if config.conf["winWizard"]["useOldCycle"]:
+			# Translators: Reported when confirm command is used while old mode is enabled.
 			ui.message(_("This command is disabled in old mode."))
 			return
 		selection = getattr(self, "_cycleSelection", None)
 		if not selection:
+			# Translators: Reported when no window is currently selected in the cycle.
 			ui.message(_("No window selected."))
 			return
 		fg = api.getForegroundObject()
 		parent = getattr(fg, "parent", None)
 		if not parent:
+			# Translators: Reported when no window is currently selected in the cycle.
 			ui.message(_("No window selected."))
 			return
 		# App mismatch check
@@ -710,12 +717,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			not hasattr(selection, "windowHandle")
 			or not winUser.isWindow(selection.windowHandle)
 		):
+			# Translators: Reported when the selected window is no longer available.
 			ui.message(_("Window no longer available."))
 			return
 		try:
 			selection.setFocus()
 			playTonesIfEnabled(180, 50)
 		except Exception:
+			# Translators: Reported when focusing the selected window fails.
 			ui.message(_("Failed to focus window."))
 		self._resetCycleState()
 	# Helper
@@ -724,8 +733,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self._cycleWindows = None
 		self._cycleIndex = None
 		self._cycleApp = None
-
-
 
 	@scriptHandler.script(
 		# Translators: Description of the keyboard command that kills currently focused process.

--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -599,6 +599,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@scriptHandler.script(
 		description=_(
 			# Translators: Description of the keyboard command
+			# allowing to jump between top-level windows of the current application.
 			"Cycles through top-level windows of the current application."
 		),
 		gesture="kb:NVDA+windows+Tab",
@@ -677,7 +678,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self._cycleWindows = windows
 		self._cycleSelection = windows[self._cycleIndex]
 		# Translators: Announces the currently selected window when cycling.
-		# {name} is the window title or Unknown window if the window has no title, {index} is current position, {total} is total windows.
+		# Translators: {name} is the window title, {index} is current position, {total} is total windows.
+		# Translators: Reported for a window with no name when cycling between top level windows.
 		ui.message(_("{name} ({index} of {total})").format(
 			name=self._cycleSelection.name or _("Unknown window"),
 			index=self._cycleIndex + 1,

--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -678,9 +678,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self._cycleWindows = windows
 		self._cycleSelection = windows[self._cycleIndex]
 		# Translators: Announces the currently selected window when cycling.
-		# Translators: {name} is the window title, {index} is current position, {total} is total windows.
-		# Translators: Reported for a window with no name when cycling between top level windows.
+		# {name} is the window title, {index} is current position, {total} is total windows.
 		ui.message(_("{name} ({index} of {total})").format(
+			# Translators: Reported for a window with no name when cycling between top level windows.
 			name=self._cycleSelection.name or _("Unknown window"),
 			index=self._cycleIndex + 1,
 			total=len(windows)
@@ -688,6 +688,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@scriptHandler.script(
 		description=_(
+			# Translators: Command description for focusing selected window.
 			"Focuses the currently selected window from the cycle."
 		),
 		gesture="kb:NVDA+windows+`",

--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -70,7 +70,7 @@ class WinWizardSettingsPanel(gsd.SettingsPanel):
 		self.useOldCycleChk = sHelper.addItem(
 			wx.CheckBox(self, label=_("Use old window cycling behavior"))
 		)
-		self.useOldCycleChk.SetValue(config.conf["winWizard"]["useOldCycle"])
+		self.useOldCycleChk.SetValue(config.conf["winWizard"]["useOldCycleBehavior"])
 
 
 	def postInit(self):
@@ -78,7 +78,7 @@ class WinWizardSettingsPanel(gsd.SettingsPanel):
 
 	def onSave(self):
 		config.conf["winWizard"]["playConfirmationBeeps"] = self.enableBeepsChk.GetValue()
-		config.conf["winWizard"]["useOldCycle"] = self.useOldCycleChk.GetValue()
+		config.conf["winWizard"]["useOldCycleBehavior"] = self.useOldCycleChk.GetValue()
 
 
 class Win32FunctionError(Exception):
@@ -579,11 +579,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		super().__init__()
 		confSpec = {
 			"playConfirmationBeeps": "boolean(default=True)",
-			"useOldCycle": "boolean(default=False)"
+			"useOldCycleBehavior": "boolean(default=False)"
 		}
 		config.conf.spec["winWizard"] = confSpec
 		self.hiddenWindowsList: hiddenWindowsList = hiddenWindowsList()
 		gsd.NVDASettingsDialog.categoryClasses.append(WinWizardSettingsPanel)
+		# Initialize cycle state
+		self._cycleIndex = None
+		self._cycleSelection = None
+		self._cycleWindows = None
+		self._cycleApp = None
 
 	def terminate(self):
 		super().terminate()
@@ -591,19 +596,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		del self.hiddenWindowsList
 		gsd.NVDASettingsDialog.categoryClasses.remove(WinWizardSettingsPanel)
 
-
-
-
-
 	@scriptHandler.script(
 		description=_(
+			# Translators: Description of the keyboard command
 			"Cycles through top-level windows of the current application."
 		),
 		gesture="kb:NVDA+windows+Tab",
 	)
-
 	def script_cycleWindows(self, gesture):
-		if config.conf["winWizard"]["useOldCycle"]:
+		if config.conf["winWizard"]["useOldCycleBehavior"]:
 			if(
 				api.getForegroundObject()
 				and api.getForegroundObject().parent
@@ -637,22 +638,20 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 
 		fg = api.getForegroundObject()
-		parent = getattr(fg, "parent", None)
+		parent = fg.parent if hasattr(fg, "parent") else None
 		if not parent:
 			# Translators: Reported when informations for the current window cannot be retrieved.
 			ui.message(_("Can't retrieve window information for this object."))
 			return
 		appModule = parent.appModule
-		# Reset cycle state if app changed
-		if getattr(self, "_cycleApp", None) != appModule:
-			self._cycleIndex = None
-			self._cycleSelection = None
-			self._cycleWindows = None
-			self._cycleApp = appModule
 		if appModule.appName == "explorer":
 			# Translators: Information given when user tries to move to top-level window in Windows  Explorer.
 			ui.message(_("Not supported here."))
 			return
+		# Reset cycle state if app changed
+		if self._cycleApp != appModule:
+			self._resetCycleState()
+			self._cycleApp = appModule
 		# Build window list
 		windows = []
 		current = parent
@@ -667,7 +666,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			ui.message(_("This window has no top level windows to cycle to."))
 			return
 		# Initialize index if needed
-		if getattr(self, "_cycleIndex", None) is None:
+		if self._cycleIndex is None:
 			try:
 				self._cycleIndex = windows.index(parent)
 			except ValueError:
@@ -678,7 +677,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self._cycleWindows = windows
 		self._cycleSelection = windows[self._cycleIndex]
 		# Translators: Announces the currently selected window when cycling.
-		# {name} is the window title, {index} is current position, {total} is total windows.
+		# {name} is the window title or Unknown window if the window has no title, {index} is current position, {total} is total windows.
 		ui.message(_("{name} ({index} of {total})").format(
 			name=self._cycleSelection.name or _("Unknown window"),
 			index=self._cycleIndex + 1,
@@ -692,23 +691,23 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gesture="kb:NVDA+windows+`",
 	)
 	def script_confirmCycleWindow(self, gesture):
-		if config.conf["winWizard"]["useOldCycle"]:
+		if config.conf["winWizard"]["useOldCycleBehavior"]:
 			# Translators: Reported when confirm command is used while old mode is enabled.
 			ui.message(_("This command is disabled in old mode."))
 			return
-		selection = getattr(self, "_cycleSelection", None)
+		selection = self._cycleSelection
 		if not selection:
 			# Translators: Reported when no window is currently selected in the cycle.
 			ui.message(_("No window selected."))
 			return
 		fg = api.getForegroundObject()
-		parent = getattr(fg, "parent", None)
+		parent = fg.parent if hasattr(fg, "parent") else None
 		if not parent:
 			# Translators: Reported when no window is currently selected in the cycle.
 			ui.message(_("No window selected."))
 			return
 		# App mismatch check
-		if getattr(self, "_cycleApp", None) != parent.appModule:
+		if self._cycleApp != parent.appModule:
 			ui.message(_("No window selected."))
 			self._resetCycleState()
 			return
@@ -722,10 +721,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		try:
 			selection.setFocus()
-			playTonesIfEnabled(180, 50)
-		except Exception:
+		except Exception as e:
+			log.exception("Failed to focus window: %s", e)
 			# Translators: Reported when focusing the selected window fails.
 			ui.message(_("Failed to focus window."))
+		else:
+			playTonesIfEnabled(180, 50)
 		self._resetCycleState()
 	# Helper
 	def _resetCycleState(self):

--- a/addon/globalPlugins/winWizard.py
+++ b/addon/globalPlugins/winWizard.py
@@ -719,6 +719,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# Translators: Reported when the selected window is no longer available.
 			ui.message(_("Window no longer available."))
 			return
+		# Check if the selected window is already focused
+		try:
+			focusHandle = winUser.getForegroundWindow()
+			if selection.windowHandle == focusHandle:
+				# Translators: Reported when the selected window is already focused.
+				ui.message(_("Already focused"))
+				self._resetCycleState()
+				return
+		except Exception as e:
+			log.exception("Failed to check foreground window: %s", e)
 		try:
 			selection.setFocus()
 		except Exception as e:

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ Also, allows exploration of top level windows (windows+NVDA+tab),
 and kill a non responding process with windows f4."""
 	),
 	# version
-	"addon_version": "5.0.10",
+	"addon_version": "5.0.7",
 	# Author(s)
 	"addon_author": u"Oriol Gomez <ogomez.s92@gmail.com>, Łukasz Golonka <lukasz.golonka@mailbox.org>, Jakub Lukowicz <jakubl7545@gmail.com>",
 	# URL for the add-on documentation support

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ Also, allows exploration of top level windows (windows+NVDA+tab),
 and kill a non responding process with windows f4."""
 	),
 	# version
-	"addon_version": "5.0.7",
+	"addon_version": "5.0.10",
 	# Author(s)
 	"addon_author": u"Oriol Gomez <ogomez.s92@gmail.com>, Łukasz Golonka <lukasz.golonka@mailbox.org>, Jakub Lukowicz <jakubl7545@gmail.com>",
 	# URL for the add-on documentation support

--- a/readme.md
+++ b/readme.md
@@ -3,29 +3,41 @@
 * Author: Oriol Gómez, Łukasz Golonka, current maintenance by Jakub Lukowicz
 * NVDA compatibility: 2019.3 and beyond
 
-This add-on allows you to perform some operations on the focused window or the process associated with it.
-When killing a process, or showing / hiding a window a confirmation beep is played when the action succeeds.
+This add-on allows you to perform some operations on the focused window or the process associated with it.  
+When killing a process, or showing / hiding a window a confirmation beep is played when the action succeeds.  
 If you find this annoying you can disable these beeps in the Win Wizard's settings panel available from NVDA's settings dialog.
 
 ## Keyboard commands:
+
 All these commands can be remapped from the Input gestures dialog in the Win Wizard category.
+
 ### Hiding and showing hidden windows:
-* NVDA+Windows+numbers from 1 to 0 - hides  currently focused window in the slot corresponding to the pressed number
-* NVDA+Windows+left arrow - moves to the previous stack of hidden windows.
-* NVDA+Windows+right arrow - moves to the next stack of hidden windows.
+
+* NVDA+Windows+numbers from 1 to 0 - hides currently focused window in the slot corresponding to the pressed number
+* NVDA+Windows+left arrow - moves to the previous stack of hidden windows
+* NVDA+Windows+right arrow - moves to the next stack of hidden windows
 * Windows+Shift+h - hides the currently focused window in the first available slot
 * NVDA+Windows+h - shows the last hidden window
 * Windows+Shift+l - shows the list of all hidden windows grouped by the stacks (please note that by default last hidden window is selected)
 
 ### Managing processes:
+
 * Windows+F4 - kills the process associated with the currently focused window
 * NVDA+Windows+p - opens dialog allowing you to set priority of the process associated with the currently focused window
 
-### Miscellaneous  commands:
+### Miscellaneous commands:
+
 * NVDA+Windows+TAB - switches between top level windows of the current program (useful in foobar2000, Back4Sure etc.)
+* NVDA+Windows+` - confirms and switches to the selected window in the cycle  
+  * In the new behavior, this command is used to activate the selected window    * The old behavior can still be enabled in settings
 * CTRL+ALT+T - allows you to change title of the currently focused program
 
 ## Changes:
+
+### Changes for 5.1.0:
+
+* Added a new window cycling system with improved selection and confirmation behavior
+* Added option to switch between the new window cycling system and the legacy behavior
 
 ### Changes for 5.0.7:
 
@@ -55,3 +67,4 @@ All these commands can be remapped from the Input gestures dialog in the Win Wiz
 ### Changes for 5.0.2:
 
 * First release available from the add-ons website
+

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,13 @@ All these commands can be remapped from the Input gestures dialog in the Win Wiz
 
 * NVDA+Windows+TAB - switches between top level windows of the current program (useful in foobar2000, Back4Sure etc.)
 * NVDA+Windows+` - confirms and switches to the selected window in the cycle  
-  * In the new behavior, this command is used to activate the selected window    * The old behavior can still be enabled in settings
+  * In the new behavior, this command is used to activate the selected window
+  * The old behavior can still be enabled in settings
 * CTRL+ALT+T - allows you to change title of the currently focused program
 
 ## Changes:
 
-### Changes for 5.1.0:
+### Changes for 5.0.8:
 
 * Added a new window cycling system with improved selection and confirmation behavior
 * Added option to switch between the new window cycling system and the legacy behavior
@@ -67,4 +68,3 @@ All these commands can be remapped from the Input gestures dialog in the Win Wiz
 ### Changes for 5.0.2:
 
 * First release available from the add-ons website
-


### PR DESCRIPTION
This update improves the window cycling feature by introducing a selection + confirmation workflow.

Changes:
- Added new cycling behavior that lets users preview windows before switching
- Added confirm key (NVDA+Windows+`) to focus selected window
- Kept old cycling behavior as an option (configurable per profile)
- Updated README and changelog

Notes:
- Old behavior is preserved for compatibility
- New behavior is more controlled and avoids accidental switching